### PR TITLE
feat: Added IDBPromisedMutableFile runFileRequestGenerator method

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,10 @@
           "IDBFiles",
           "skipOnSupportedIDBMutableFile",
           "skipOnUnsupportedIDBMutableFile"
-        ]
+        ],
+        "rules": {
+          "generator-star-spacing": ["error", {"before": false, "after": true}]
+        }
       }
     ]
   }

--- a/test/unit/test.idb-promised-mutable-file.js
+++ b/test/unit/test.idb-promised-mutable-file.js
@@ -46,5 +46,43 @@ describe("IDBFiles", () => {
 
       expect(fh).to.be.instanceOf(IDBFiles.IDBPromisedFileHandle);
     });
+
+    it("should provide a runFileRequestGenerator method", async () => {
+      const tmpFiles = await IDBFiles.getFileStorage({name: "tmpFiles"});
+      const mutableFile = await tmpFiles.createMutableFile("test-mutable-file.txt");
+
+      function* fileOperations(lockedFile) {
+        expect(lockedFile.active).to.be.eql(true);
+        expect(lockedFile.location).to.be.eql(0);
+
+        lockedFile.location = 3;
+        expect(lockedFile.location).to.be.eql(3);
+
+        let expectedLocation = 3;
+        let expectedData = "\0\0\0";
+
+        for (let i = 0; i < 9; i++) {
+          const data = `test data ${i} - `;
+          expectedData += data;
+          expectedLocation += data.length;
+
+          const res = yield lockedFile.write(data);
+
+          expect(lockedFile.active).to.be.eql(true);
+          expect(lockedFile.location).to.be.eql(expectedLocation);
+          expect(res).to.be.eql(undefined);
+        }
+
+        lockedFile.location = 0;
+        expect(lockedFile.active).to.be.eql(true);
+        expect(lockedFile.location).to.be.eql(0);
+
+        const res = yield lockedFile.readAsText(expectedLocation);
+        expect(lockedFile.active).to.be.eql(true);
+        expect(res).to.be.eql(expectedData);
+      }
+
+      await mutableFile.runFileRequestGenerator(fileOperations, "readwrite");
+    });
   });
 });


### PR DESCRIPTION
The [lockedFile](https://developer.mozilla.org/en-US/docs/Web/API/LockedFile) that has to be retrieved from a [IDBMutableFile](https://developer.mozilla.org/en-US/docs/Web/API/IDBMutableFile) to be able to write and retrieve data from the MutableFile is designed to become automatically inactive as soon as the file goes idle (in other words, once there is no file DOMRequest instances that are going to write or read the lockedFile).

The IDBPromisedMutableFile class wraps the IDBMutableFile with a promised API which automatically re-open the file when a new file operation on that file has been requested, but there are chances that a developer may want to write and read data from the file and by using the promised API the lockedFile is going to become inactive after every one of the promised operator.

As an alternative of "being forced to directly subscribe the DOMRequest onsuccess/onerror callbacks" on every file operation requested used the non-promised API, we can provide a helper method in the IDBPromisifiedMutableFile which can run a sequence of DOMRequest file operations generated by a generator function and automatically schedule the next DOMRequest as soon as the previous one has been completed and allow the developer to write these sequences of file operations with an API as nice as the promised one.

As an example of this approach, follows a small example code snippet:

```js
(async function () {
  const tmpFiles = await IDBFiles.getFileStorage({name: "tmpFiles"});
  const mutableFile = await tmpFiles.createMutableFile("test-mutable-file.txt");

  let allFileData;

  function* fileOperations(lockedFile) {
    yield lockedFile.write("some data");
    yield lockedFile.write("more data");
    const metadata = yield lockedFile.getMetadata();
    
    lockedFile.location = 0;
    allFileData = yield lockedFile.readAsText(metadata.size);
  }

  await mutableFile.runFileRequestGenerator(fileOperations, "readwrite");

  console.log("File Data", allFileData);
})();
```