### PR TITLE
docs: library API docs and examples

### DIFF
--- a/.esdoc.json
+++ b/.esdoc.json
@@ -1,0 +1,1 @@
+{"source": "./src", "destination": "./doc"}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 dist/
+docs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 coverage/
 dist/
-docs/
+doc/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,9 +3,9 @@
 const path = require("path");
 
 const gulp = require("gulp");
+const babel = require("gulp-babel");
 const notify = require("gulp-notify");
 const plumber = require("gulp-plumber");
-const umd = require("gulp-umd");
 const xo = require("gulp-xo");
 const KarmaServer = require("karma").Server;
 
@@ -27,13 +27,19 @@ gulp.task("umd", function () {
     // Run js linting on every build.
     .pipe(xo())
     // Wrap as an UMD module.
-    .pipe(umd({
-      exports: function () {
-        return "IDBFiles";
-      },
-      namespace: function () {
-        return "IDBFiles";
-      }
+    .pipe(babel({
+      babelrc: false,
+      comments: true,
+      plugins: [
+        ["transform-es2015-modules-umd", {
+          globals: {
+            "idb-file-storage": "IDBFiles"
+          },
+          exactGlobals: true
+        }]
+      ],
+      sourceMap: true,
+      moduleId: "idb-file-storage"
     }))
     .pipe(gulp.dest("dist/"));
 });

--- a/package.json
+++ b/package.json
@@ -19,12 +19,15 @@
   "author": "Luca Greco <lgreco@mozilla.com>",
   "license": "MPL-2.0",
   "devDependencies": {
+    "babel": "^6.23.0",
     "babel-plugin-istanbul": "^4.0.0",
+    "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+    "babel-preset-babili": "0.0.12",
     "chai": "^3.5.0",
     "gulp": "^3.9.1",
+    "gulp-babel": "^6.1.2",
     "gulp-notify": "^3.0.0",
     "gulp-plumber": "^1.1.0",
-    "gulp-umd": "^0.2.0",
     "gulp-xo": "^0.14.0",
     "karma": "^1.5.0",
     "karma-babel-preprocessor": "^6.0.1",
@@ -51,7 +54,8 @@
       ]
     },
     "ignored": [
-      "dist/**"
+      "dist/**",
+      "docs/**"
     ],
     "overrides": [
       {
@@ -69,7 +73,13 @@
           "skipOnUnsupportedIDBMutableFile"
         ],
         "rules": {
-          "generator-star-spacing": ["error", {"before": false, "after": true}]
+          "generator-star-spacing": [
+            "error",
+            {
+              "before": false,
+              "after": true
+            }
+          ]
         }
       }
     ]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "gulp",
     "build:watch": "gulp default:watch",
     "test": "xo --reporter codeframe && npm run build && karma start --single-run",
-    "test:watch": "gulp test:watch"
+    "test:watch": "gulp test:watch",
+    "docs": "esdoc"
   },
   "keywords": [
     "IndexedDB",
@@ -24,6 +25,7 @@
     "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "babel-preset-babili": "0.0.12",
     "chai": "^3.5.0",
+    "esdoc": "^0.5.2",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-notify": "^3.0.0",

--- a/src/idb-file-storage.js
+++ b/src/idb-file-storage.js
@@ -1,6 +1,6 @@
 "use strict";
 
-function waitForDOMRequest(req, onsuccess) {
+export function waitForDOMRequest(req, onsuccess) {
   return new Promise((resolve, reject) => {
     req.onsuccess = onsuccess ?
       (() => resolve(onsuccess(req.result))) : (() => resolve(req.result));
@@ -8,7 +8,7 @@ function waitForDOMRequest(req, onsuccess) {
   });
 }
 
-class IDBPromisedFileHandle {
+export class IDBPromisedFileHandle {
   constructor({file, lockedFile}) {
     this.file = file;
     this.lockedFile = lockedFile;
@@ -141,7 +141,7 @@ class IDBPromisedFileHandle {
   }
 }
 
-class IDBPromisedMutableFile {
+export class IDBPromisedMutableFile {
   constructor({filesStorage, idb, fileName, fileType, mutableFile}) {
     this.filesStorage = filesStorage;
     this.idb = idb;
@@ -210,7 +210,7 @@ class IDBPromisedMutableFile {
   }
 }
 
-class IDBFileStorage {
+export class IDBFileStorage {
   constructor({name, persistent} = {}) {
     this.name = name;
     this.persistent = persistent;
@@ -363,14 +363,8 @@ class IDBFileStorage {
   }
 }
 
-const IDBFiles = { // eslint-disable-line no-unused-vars
-  waitForDOMRequest,
-  IDBFileStorage,
-  IDBPromisedMutableFile,
-  IDBPromisedFileHandle,
-  async getFileStorage({name} = {}) {
-    const filesStorage = new IDBFileStorage({name: name || "default"});
-    await filesStorage.initializedDB();
-    return filesStorage;
-  }
-};
+export async function getFileStorage({name} = {}) {
+  const filesStorage = new IDBFileStorage({name: name || "default"});
+  await filesStorage.initializedDB();
+  return filesStorage;
+}


### PR DESCRIPTION
This PR contains the changes needed to introduce esdoc (which aims to fix #6).

`esdoc` natively supports ES6 syntax and it is going to include anything that the module exports into the API docs (and it keeps track of the API docs coverage based on it).

To allow `esdoc` to automatically recognize the library exports, the first step is to port the sources to the ES6 module syntax and use `gulp-babel` and `babel-plugin-transform-es2015-modules-umd` to convert the ES6 module syntax into an UMD module (instead of `gulp-umd`). 
